### PR TITLE
Bountysource is not discontinued, just needs www

### DIFF
--- a/posts/bounty-source.md
+++ b/posts/bounty-source.md
@@ -1,25 +1,25 @@
 ---
 title: "Bounty Source"
-date: 2020-06-20T08:20:00+02:00
+date: 2020-08-04T12:20:00+02:00
 type: post
 categories:
 - Bounties
 - Crowdfunding
 - Donations
 tags:
-- Discontinued
+- Live
 - Developer friendly
 draft: false
 images:
 - /images/bounty-source.png
 comments: true
-lastmod: 2020-06-20T08:20:00+02:00
-link: "https://bountysource.com/"
+lastmod: 2020-08-04T12:20:00+02:00
+link: "https://www.bountysource.com/"
 description: "Bountysource is the funding platform for open-source software by creating/collecting bounties and pledging to fundraisers."
 organization: "Corporation"
 monetization: "Bounties, Crowdfunding, Donations."
-technology: "Close source"
-status: "Discontinued"
+technology: "Open source"
+status: "Live"
 activity: 0
 payment_services: "PayPal, Bitcoin, Check"
 fee: "10%"


### PR DESCRIPTION
The redirect from naked domain is broken, but Bountysource is live
also it's not closed, it's Open Source https://github.com/bountysource