### PR TITLE
Snowdrift.coop isn't closed-source

### DIFF
--- a/posts/snowdrift.md
+++ b/posts/snowdrift.md
@@ -1,6 +1,6 @@
 ---
 title: "Snowdrift"
-date: 2020-06-20T08:20:00+02:00
+date: 2020-08-04T08:20:00+02:00
 type: post
 categories:
 - Crowdfunding
@@ -14,13 +14,13 @@ draft: false
 images:
 - /images/snowdrift.png
 comments: true
-lastmod: 2020-06-20T08:20:00+02:00
+lastmod: 2020-08-04T08:20:00+02:00
 link: "https://snowdrift.coop/"
 twitter: SnowdriftCoop
 description: "A nonprofit cooperative for funding public goods – things like software, music, journalism, and research."
 organization: "Non-profit"
 monetization: "Donations with matching limits"
-technology: "Close source"
+technology: "Open source"
 status: "In-development"
 activity: 0
 payment_services: "Paypal, Bitcoin"


### PR DESCRIPTION
Why was that marked that way? It's very boldly stated as 100% FLO.
https://gitlab.com/snowdrift/snowdrift/ is linked right from the footer of the site